### PR TITLE
Fix integration test incorrectly succeeding

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -14,10 +14,13 @@ jobs:
       - run: |
           echo "MC_VER=$(cat Dockerfile | grep MC_VER= | awk -F "=" '{print $2}')" >> $GITHUB_ENV
 
-      - name: Run integration tests
+      - name: Build and run server
         run: |
           docker compose build --no-cache
           docker compose up -d
+
+      - name: Run integration tests
+        run: |
           ./mccli check_server
       
       - run: |

--- a/mccli
+++ b/mccli
@@ -27,12 +27,16 @@ function check_server() {
     do
         echo -n " check attempt $_attempts..."
         docker compose exec -it server bash -c "mc-monitor status-bedrock --host 127.0.0.1" >/dev/null 2>&1
-        if (( $? == 0 )) || (( $_attempts > $_max_rety )); then
+        if (( $? == 0 )); then
             echo "success"
             break
         fi
         echo "failed"
         _attempts=$((_attempts+1))
+        if (( $_attempts > $_max_rety )); then
+            echo "max retries reached, exiting..."
+            exit 1
+        fi
         sleep 5
     done
 


### PR DESCRIPTION
The `check_server` function in `mccli` would incorrectly record success if the max retries was reached.  Moved the check of the retry count to it's own conditional check.